### PR TITLE
Fix #15. Now supports fully commented input.

### DIFF
--- a/pp-toml-tests.asd
+++ b/pp-toml-tests.asd
@@ -4,10 +4,10 @@
                 #:cl-ppcre
                 #:esrap
                 #:fiveam
+                #:generic-comparability
                 #:local-time
                 #:parse-number
                 #:split-sequence
-
 
                 #:pp-toml
                 )

--- a/pp-toml-tests.lisp
+++ b/pp-toml-tests.lisp
@@ -1,7 +1,8 @@
 (defpackage :pp-toml-tests
   (:use :common-lisp
         :pp-toml
-        :fiveam)
+        :fiveam
+        :generic-comparability)
   (:export :run-tests))
 
 (in-package :pp-toml-tests)
@@ -164,7 +165,6 @@ dob2 = 2013-10-22T07:32:00Z
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (test parse-tests
-
   (is
    (pp-toml:parse-string "title = \"TOML Example\"
 [foo]
@@ -202,3 +202,14 @@ enabled = true
   ip = \"10.0.0.2\"
   dc = \"eqdc10\"
 "))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(test top-level-tests
+      (is (equals (pp-toml:parse-toml " ")
+                  (make-hash-table :test #'equal)))
+      (is (equals (pp-toml:parse-toml "# fooo ")
+                  (make-hash-table :test #'equal)))
+      (is (equals (pp-toml:parse-toml "# fooo
+
+# bar ")
+                  (make-hash-table :test #'equal))))

--- a/pp-toml.asd
+++ b/pp-toml.asd
@@ -1,11 +1,14 @@
 (asdf:defsystem #:pp-toml
-  :depends-on ( #:esrap
-                #:parse-number
-                #:alexandria #:split-sequence #:cl-ppcre
-                #:local-time)
+  :depends-on (#:alexandria
+               #:cl-ppcre
+               #:generic-comparability
+               #:local-time
+               #:parse-number
+               #:split-sequence
+               #:esrap)
   :components ((:file "pp-toml"))
   :name "pp-toml"
-  :version "1.0"
+  :version "1.0.1"
   :maintainer "Paul Nathan <pnathan@alumni.uidaho.edu>"
   :author "Paul Nathan <pnathan@alumni.uidaho.edu>"
   :licence "LLGPL"

--- a/pp-toml.lisp
+++ b/pp-toml.lisp
@@ -14,7 +14,8 @@
 (defpackage :pp-toml
   (:use
    :common-lisp
-   :esrap)
+   :esrap
+   :generic-comparability)
   (:export
    #:parse-toml
 
@@ -408,9 +409,14 @@ Toml does not support references  as of v0.1, and there for we can traverse arra
 
 `strict` is not supported at present.
 "
+  ;; not supported
+  (declare (ignore strict))
+
   (let ((postfix-newlined-string
           (cl-ppcre:regex-replace-all "\\b\\s*$" string
                                       (concatenate 'string '(#\Newline)))))
-   (extract-lisp-structure
-    (parse-string
-     (strip-comments postfix-newlined-string)))))
+   (let ((cleaned-string (strip-comments postfix-newlined-string)))
+     (if (cl-ppcre:scan "^\\s*$" cleaned-string)
+         (make-hash-table :test #'equal)
+         (extract-lisp-structure
+          (parse-string cleaned-string))))))


### PR DESCRIPTION
Short circuit after we strip comments out, returning an appropriately
empty hash table.  See new test cases for examples.

Also added GENERIC-COMPARABILITY as a dependency to allow easy
comparison of hash tables.

This bumps the version to 1.0.1, as it only bugfixes the API.