### PR TITLE
ECL does not have \Form, removing it from the reader.

### DIFF
--- a/pp-toml-tests.asd
+++ b/pp-toml-tests.asd
@@ -13,7 +13,7 @@
                 )
   :components ((:file "pp-toml-tests"))
   :name "pp-toml-tests"
-  :version "1.0"
+  :version "1.0.1"
   :maintainer "Paul Nathan"
   :author "Paul Nathan"
   :licence "LLGPL"

--- a/pp-toml.lisp
+++ b/pp-toml.lisp
@@ -8,7 +8,7 @@
 ;;;;
 ;;;; Uses esrap for the parsing heavy lifting. Some errors may look esrapy.
 ;;;;
-;;;; (C) 2013, 2014 Paul Nathan
+;;;; (C) 2013-2021 Paul Nathan & contributors
 ;;;; License: LLGPL (http://opensource.franz.com/preamble.html)
 
 (defpackage :pp-toml
@@ -98,8 +98,8 @@
                          (string repl)))))
     ;; alpha sorted
     (tr "\\b" #\Backspace)
-    ;; ABCL does not include #\Form
-    #-abcl(tr "\\f" #\Form)
+    ;; ABCL, ECL do not include #\Form
+    #-(or abcl ecl)(tr "\\f" #\Form)
     (tr "\\n" #\Linefeed)
     (tr "\\r" #\Return)
     (tr "\\t" #\Tab)


### PR DESCRIPTION
Closes #20